### PR TITLE
fix: Align the icon with the text

### DIFF
--- a/tour/tour.css
+++ b/tour/tour.css
@@ -16,7 +16,7 @@
 
 i {
 	font-size: 1.25em !important;
-	vertical-align: top;
+	vertical-align: middle;
 }
 
 /* showmore arrow */

--- a/tour/tour.css
+++ b/tour/tour.css
@@ -16,7 +16,7 @@
 
 i {
 	font-size: 1.25em !important;
-	vertical-align: middle;
+	vertical-align: text-top;
 }
 
 /* showmore arrow */


### PR DESCRIPTION
I made a small change to align the icon with the text next to it.

Before:
![image](https://user-images.githubusercontent.com/108533817/233102680-dfbce800-7ab9-4de1-b5f2-3f1a32f7a1aa.png)
After:
![image](https://user-images.githubusercontent.com/108533817/233102955-aa2b7d1a-2b22-4ca5-b8bf-4c5bd3b583da.png)

